### PR TITLE
List maps as {url, name} entries.

### DIFF
--- a/maps/v1_serializers.py
+++ b/maps/v1_serializers.py
@@ -2,6 +2,7 @@
 # Serializers define the API representation.
 
 from rest_framework_gis.serializers import GeoFeatureModelSerializer
+from rest_framework.serializers import ModelSerializer
 from maps.models import Map, Feature
 
 
@@ -11,6 +12,13 @@ class MapSerializer(GeoFeatureModelSerializer):
         geo_field = 'bbox'
         fields = ('name', 'bbox', 'public', 'editable')
         auto_bbox = True
+
+
+class MapListSerializer(ModelSerializer):
+    class Meta:
+        model = Map
+        fields = ('url', 'name')
+        read_only_fields = ('url',)
 
 
 class FeatureSerializer(GeoFeatureModelSerializer):

--- a/maps/v1_views.py
+++ b/maps/v1_views.py
@@ -3,12 +3,16 @@ from rest_framework import viewsets
 
 # ViewSets define the view behavior.
 from maps.models import Map, Feature
-from maps.v1_serializers import MapSerializer, FeatureSerializer
+from maps.v1_serializers import MapSerializer, MapListSerializer, FeatureSerializer
 
 
 class MapViewSet(viewsets.ModelViewSet):
     queryset = Map.objects.all()
-    serializer_class = MapSerializer
+
+    def get_serializer_class(self):
+        if self.action == 'list':
+            return MapListSerializer
+        return MapSerializer
 
 
 class FeatureViewSet(viewsets.ModelViewSet):


### PR DESCRIPTION
The serializer for listing is overwritten to use return a json object instead
of a geojson feature. Resolves #14 
